### PR TITLE
トップ画面作成

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -50,6 +50,10 @@ gem 'acts-as-taggable-on'
 gem 'rails-i18n'
 
 gem 'devise-i18n'
+
+gem 'faker'
+
+gem 'kaminari'
 ### ここまで ###
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,6 +114,8 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     erubi (1.13.1)
+    faker (3.5.1)
+      i18n (>= 1.8.11, < 2)
     ffi (1.17.1-aarch64-linux-gnu)
     ffi (1.17.1-x86_64-linux-gnu)
     font-awesome-sass (6.7.2)
@@ -134,6 +136,18 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     json (2.9.1)
+    kaminari (1.2.2)
+      activesupport (>= 4.1.0)
+      kaminari-actionview (= 1.2.2)
+      kaminari-activerecord (= 1.2.2)
+      kaminari-core (= 1.2.2)
+    kaminari-actionview (1.2.2)
+      actionview
+      kaminari-core (= 1.2.2)
+    kaminari-activerecord (1.2.2)
+      activerecord
+      kaminari-core (= 1.2.2)
+    kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
     logger (1.6.4)
     loofah (2.24.0)
@@ -327,9 +341,11 @@ DEPENDENCIES
   devise
   devise-i18n
   draper
+  faker
   font-awesome-sass
   importmap-rails
   jbuilder
+  kaminari
   meta-tags
   mysql2 (~> 0.5)
   pry

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,4 +1,8 @@
 class PostsController < ApplicationController
+  def index
+    @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
   def show
     @post = Post.find(params[:id])
   end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -10,23 +10,21 @@
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_importmap_tags %>
   </head>
-  <%# ------動作確認用のコード------ %> 
-  <header>
-   <% if user_signed_in? %>
-     <li>
-       <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
-     </li>
-   <% else %>
-     <li>
-       <%= link_to "新規登録", new_user_registration_path %>
-     </li>
-     <li>
-       <%= link_to "ログイン", new_user_session_path %>
-     </li>
-   <% end %>
-  </header>
-  <%# ------ここまで------ %>
   <body>
+    <header>
+      <% if user_signed_in? %>
+        <li>
+          <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
+        </li>
+      <% else %>
+        <li>
+          <%= link_to "新規登録", new_user_registration_path %>
+        </li>
+        <li>
+          <%= link_to "ログイン", new_user_session_path %>
+        </li>
+      <% end %>
+    </header>
     <div class="container mt-10 px-10">
       <p class="notice"><%= notice %></p>
       <p class="alert"><%= alert %></p>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -1,0 +1,10 @@
+<div class="flex flex-col rounded-lg border border-gray-200 p-4 hover:shadow-lg transition-shadow duration-300">
+  <h3 class="mb-2 text-lg font-semibold text-[#F49340] md:text-xl">
+    <%= link_to post.title, post_path(post) %> <!-- ポストタイトル -->
+  </h3>
+  <ul class="list-inline mb-4">
+    <li class="flex items-center text-sm text-gray-600">
+      <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='1em' height='1em' viewBox='0 0 24 24'%3E%3Cpath fill='%23888888' d='M11.5 14c4.14 0 7.5 1.57 7.5 3.5V20H4v-2.5c0-1.93 3.36-3.5 7.5-3.5m6.5 3.5c0-1.38-2.91-2.5-6.5-2.5S5 16.12 5 17.5V19h13zM11.5 5A3.5 3.5 0 0 1 15 8.5a3.5 3.5 0 0 1-3.5 3.5A3.5 3.5 0 0 1 8 8.5A3.5 3.5 0 0 1 11.5 5m0 1A2.5 2.5 0 0 0 9 8.5a2.5 2.5 0 0 0 2.5 2.5A2.5 2.5 0 0 0 14 8.5A2.5 2.5 0 0 0 11.5 6'/%3E%3C/svg%3E" alt="User Icon" class="w-6 h-6 text-gray-600"><i class="bi bi-person"></i><!-- アイコンを表示 --><%= post.user.name %><!-- ユーザー名を表示 -->
+    </li>
+  </ul>
+</div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -1,0 +1,51 @@
+<div class="bg-white py-6 sm:py-8 lg:py-12 mx-auto">
+  <!-- text - start -->
+  <div class="mb-10 md:mb-16">
+    <!-- トグルボタン -->
+    <h2 class="mb-4 text-left text-2xl font-bold text-[#373735] md:mb-6 lg:text-2xl cursor-pointer" onclick="toggleDetails()">
+      ▼RUNTEQ百科事典とは？
+    </h2>
+
+    <!-- トグルされるコンテンツ -->
+    <div id="toggleContent" class="transition-all duration-300 overflow-hidden max-h-0 opacity-0">
+      <ul class="mx-auto max-w-screen-md text-left text-[#373735] md:text-md space-y-2 list-disc list-inside">
+        <li>RUNTEQコミュニティ内で起こった印象的なワードやエピソードを記録するwikiアプリです</li>
+        <li>楽しかった思い出や苦労した課題や開発などを記録し、卒業時に見返すことでRUNTEQ生活を振り返れるアルバムのようなアプリを目指しています</li>
+      </ul>
+    </div>
+  </div>
+  <!-- text - end -->
+
+  <!-- posts - start -->
+  <div class="mb-4">
+    <h3 class="text-left text-xl font-bold text-[#373735]">登録ワード一覧</h3>
+  </div>
+  <!-- モバイルでは1列、タブレットでは2列、PC以上の大きな画面では3列で表示 -->
+  <div class="grid gap-4 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3 w-full justify-center">
+    <% if @posts.present? %>
+      <!-- 各ポストをループして表示 -->
+      <%= render @posts %>
+      <%= paginate @posts %>
+    <% else %>
+      <!-- ポストがない場合のメッセージ -->
+      <div class="col-span-3 text-center mb-3 text-gray-600">掲示板がありません</div>
+    <% end %>
+  </div>
+  <!-- posts - end -->
+</div>
+
+<!-- JavaScript -->
+<script>
+  function toggleDetails() {
+    var content = document.getElementById("toggleContent");
+
+    // トグルでmax-heightとopacityを制御
+    if (content.classList.contains("max-h-0")) {
+      content.classList.remove("max-h-0", "opacity-0");
+      content.classList.add("max-h-full", "opacity-100");
+    } else {
+      content.classList.remove("max-h-full", "opacity-100");
+      content.classList.add("max-h-0", "opacity-0");
+    }
+  }
+</script>

--- a/config/initializers/kaminari_config.rb
+++ b/config/initializers/kaminari_config.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+Kaminari.configure do |config|
+  config.default_per_page = 9
+  # config.max_per_page = nil
+  # config.window = 4
+  # config.outer_window = 0
+  # config.left = 0
+  # config.right = 0
+  # config.page_method_name = :page
+  # config.param_name = :page
+  # config.max_pages = nil
+  # config.params_on_first_page = false
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -11,6 +11,7 @@ Rails.application.routes.draw do
 
   # Defines the root path route ("/")
   # root "articles#index"
+  root 'posts#index'
   resources :posts, only: %i[show] do
     resources :episodes, only: %i[create edit destroy], shallow: true
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,3 +7,15 @@
 #
 #   movies = Movie.create([{ name: "Star Wars" }, { name: "Lord of the Rings" }])
 #   Character.create(name: "Luke", movie: movies.first)
+10.times do
+  User.create!(name: Faker::Name.name,
+    email: Faker::Internet.unique.email,
+    password: "password",
+    password_confirmation: "password")
+end
+
+user_ids = User.ids
+20.times do |index|
+  user = User.find(user_ids.sample)
+  user.posts.create!(title: "タイトル#{index}", body: "本文#{index}")
+end


### PR DESCRIPTION
# 概要
トップ画面の作成を行いました。

## やったこと
- gem 'faker'導入（テストユーザー作成のため）
- gem 'kaminari'（ページネーションのため）
- 一覧ページを表示

## やらないこと
- ページネーションの見た目部分は、BootStrapはデフォルトで作成されるが、TailWindCSSでは別途viewファイルが必要。
- Tagの表示は別Issueで実装予定。
## できるようになること（ユーザー目線）
- 各投稿タイトルをクリックして、ワード詳細画面に遷移できます。
- ページネーションで9投稿ずつ閲覧できます。
- ▼RUNTEQ百科事典 をクリックすると、アプリの説明が表示されます。
## 動作確認とその方法
(http://localhost:3001/)にアクセスすることで確認できます。
```
 root 'posts#index'
```
上記記述により一覧ページをトップ画面にしています。
## その他
プルリクを作成しました。
feature/03_topで当初作業をしていましたが、mainのpullが抜けていたことでmergeができない状況になり、このfeature/03_top_rev2ブランチを新しく切りました。

## 実際の画面
[![Image from Gyazo](https://i.gyazo.com/6ea0f76d9dbe575075c5f5a694c90ad2.png)](https://gyazo.com/6ea0f76d9dbe575075c5f5a694c90ad2)