### PR TITLE
4-4-2. 共通機能：フラッシュメッセージパーシャルの実装

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -7,10 +7,10 @@
     @apply py-2 px-4 bg-blue-200;
   } */
   .alert-success{
-    @apply p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400;
+    @apply p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50;
   }
   .alert-danger{
-    @apply p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400;
+    @apply p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50;
   }
 }
 

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -6,10 +6,20 @@
   /* .btn-primary {
     @apply py-2 px-4 bg-blue-200;
   } */
+  /* 成功フラッシュメッセージ */
   .alert-success{
     @apply p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50;
   }
+  /* 成功フラッシュメッセージ(Device関連) */
+  .alert-notice{
+    @apply p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50;
+  }
+  /* 失敗フラッシュメッセージ */
   .alert-danger{
+    @apply p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50;
+  }
+  /* 失敗フラッシュメッセージ(Device関連) */
+  .alert-alert{
     @apply p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50;
   }
 }

--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -2,12 +2,15 @@
 @tailwind components;
 @tailwind utilities;
 
-/*
-
 @layer components {
-  .btn-primary {
+  /* .btn-primary {
     @apply py-2 px-4 bg-blue-200;
+  } */
+  .alert-success{
+    @apply p-4 mb-4 text-sm text-green-800 rounded-lg bg-green-50 dark:bg-gray-800 dark:text-green-400;
+  }
+  .alert-danger{
+    @apply p-4 mb-4 text-sm text-red-800 rounded-lg bg-red-50 dark:bg-gray-800 dark:text-red-400;
   }
 }
 
-*/

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  add_flash_types :success, :danger
   # def current_or_guest_user
   #   current_user || gest_user = User.find(0) || User.create!(id: 0, name: "Gest", email: "gest@test.com", password: "gestuser")
   # end

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -4,11 +4,12 @@ class EpisodesController < ApplicationController
   def create
     @episode = current_or_guest_user.episodes.build(episode_params)
     if @episode.save
-      redirect_to post_path(episode_params[:post_id])
+      redirect_to post_path(episode_params[:post_id]),success: 'エピソードを投稿しました'
       # redirect_to  ワード詳細ページ＆成功フラッシュメッセージ「エピソードを投稿しました」
     else
       @post = Post.find(episode_params[:post_id])
       @episodes = @post.episodes.includes(:user).order(created_at: :desc)
+      flash.now[:danger] = 'エピソードを投稿できませんでした'
       render template: "posts/show", status: :unprocessable_entity
       # render: ワード詳細ページ＆失敗フラッシュメッセージ「エピソードを投稿できませんでした」
     end

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -5,13 +5,11 @@ class EpisodesController < ApplicationController
     @episode = current_or_guest_user.episodes.build(episode_params)
     if @episode.save
       redirect_to post_path(episode_params[:post_id]),success: 'エピソードを投稿しました'
-      # redirect_to  ワード詳細ページ＆成功フラッシュメッセージ「エピソードを投稿しました」
     else
       @post = Post.find(episode_params[:post_id])
       @episodes = @post.episodes.includes(:user).order(created_at: :desc)
       flash.now[:danger] = 'エピソードを投稿できませんでした'
       render template: "posts/show", status: :unprocessable_entity
-      # render: ワード詳細ページ＆失敗フラッシュメッセージ「エピソードを投稿できませんでした」
     end
   end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,11 +16,10 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <div class="container mt-10 px-10">
-      <p class="notice"><%= notice %></p>
-      <p class="alert"><%= alert %></p>
-    </div>  
-    <main class="container mx-auto mt-10 px-5 flex">     
+    <div class="container mx-auto mt-10 px-10">
+      <%= render 'shared/flash_message' %>
+    </div>
+    <main class="container mx-auto mt-10 px-5 flex">
       <%= yield %>
     </main>
   </body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,7 +16,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
-    <div class="container mx-auto mt-10 px-10">
+    <div class="container mx-auto mt-5">
       <%= render 'shared/flash_message' %>
     </div>
     <main class="container mx-auto mt-10 px-5 flex">

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,5 @@
+<% flash.each do |message_type, message| %>
+  <div class="alert-<%= message_type %>">
+    <%= message %>
+  </div>
+<% end %>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -19,5 +19,5 @@ module.exports = {
     // require('@tailwindcss/typography'),
     // require('@tailwindcss/container-queries'),
   ],
-  sefelist: ['alert-success', 'alert-danger'],
+  safelist: ['alert-success', 'alert-danger'],
 }

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -18,5 +18,6 @@ module.exports = {
     // require('@tailwindcss/forms'),
     // require('@tailwindcss/typography'),
     // require('@tailwindcss/container-queries'),
-  ]
+  ],
+  sefelist: ['alert-success', 'alert-danger'],
 }

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -19,5 +19,5 @@ module.exports = {
     // require('@tailwindcss/typography'),
     // require('@tailwindcss/container-queries'),
   ],
-  safelist: ['alert-success', 'alert-danger'],
+  safelist: ['alert-success', 'alert-notice','alert-danger', 'alert-alert'],
 }


### PR DESCRIPTION
Close #27 
# 概要
[# 4-4-2. 共通機能：フラッシュメッセージパーシャル](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/27)対応

## やったこと
1. フラッシュタイプの追加
    - success
    - danger
2.  `shared/_flash_message.html.erb` パーシャルの作成・編集
3. `layouts/application.html.erb` で `_flash_message` パーシャルの読み込み
4. `app/assets/stylesheets/application.tailwind.css` に、TailWindCSSのカスタムCSSを作成
    - `alert-success`…成功・通知系フラッシュメッセージ表示用
        - 薄い緑背景、緑文字
    - `alert-danger`…失敗・警告系フラッシュメッセージ表示用
        - 薄い赤背景、赤文字
    - `alert-notice`…成功・通知系フラッシュメッセージ表示用(Device用)
        - 薄い緑背景、緑文字
    - `alert-alert`…失敗・警告系フラッシュメッセージ表示用(Device用)
        - 薄い赤背景、赤文字
    -  <参考>
    [tailwindにカスタムクラスを追加する](https://zenn.dev/cordelia/scraps/45cbb80daee332)
    [tailwindcss-Adding custom styles](https://tailwindcss.com/docs/adding-custom-styles#adding-component-classes)
    [tailwindcss-Functions and directives](https://tailwindcss.com/docs/functions-and-directives#apply)


5. 動的に指定したクラス名でもカスタムCSSが適用されるように設定

    - 実施内容
    `config/tailwind.config.js` の `safelist` オプションに、使用するカスタムCSSクラス（`alert-success` `alert-danger` `alert-notice` `alert-alert`）を指定した

    - 背景
    カスタムCSSは、`_flash_message` パーシャル内で以下のように動的にクラスを指定している。
        ```erb
        <div class="alert-<%= message_type %>">
        ```
      しかし、Tailwind CSSの仕様により、ビルド時にHTML内で直接確認できるクラスのみが出力されるため、`alert-success` `alert-danger` `alert-notice` `alert-alert` のクラスが適用されなかった。
      そこで、`config/tailwind.config.js` の `safelist` オプションを利用し、これらのクラスを明示的に指定することで、常に出力するように設定を行った。
    - 参考
    [Tailwind CSSで、よく使いそうなのにやり方がわからなかったこと](https://qiita.com/webbingstudio@github/items/27cb99334bdfce503282)
      > Tailwind CSSはバージョン3以降、CSSをビルドしたときに公開ディレクトリのHTMLを解析し、存在しているクラスのみを書き出すようになりました。この場合、例えばJavaScriptやPHPなどで、動的に書き換えられたときのクラスを書き出してくれません。HTMLに存在していないからです。

      [Tailwind CSSの嬉しいけど嬉しくない機能 - Just In Time Mode](https://qiita.com/webbingstudio@github/items/27cb99334bdfce503282)
      [tailwind.config.js のよく使う設定](https://qiita.com/99no_exit/items/809fd7c3cbc2ffcaf7df#safelist)




7. `layouts/application.html.erb`に記載されていた、Device用のフラッシュメッセージ表示部を削除
8. エピソード投稿機能のフラッシュメッセージ表示
(動作確認用で実装しました)

## やらないこと
1. 既存のフラッシュタイプの変更
    - notice　→ success
    - alert → danger
1. 各機能のフラッシュメッセージ表示の追加
今回は、フラッシュメッセージをヘッダーの下に表示できるようにしただけになります。
既に、フラッシュメッセージを表示させている機能(ログイン機能・エピソードの投稿)については、フラッシュメッセージが表示されますが、それ以外の機能(ユーザー登録・ワード登録など)のフラッシュメッセージの追加は行っていません。適宜、機能の実装をお願いします。

## できるようになること(ユーザ目線)
1. ログイン時の成功・失敗時のフラッシュメッセージ表示
2. エピソード投稿時の投稿成功・失敗のフラッシュメッセージ表示

## できなくなること(ユーザ目線)
なし

## 影響範囲
フラッシュメッセージを表示する全機能

## 動作確認とその方法
1. [ログイン画面](http://localhost:3001/users/sign_in)にアクセスし以下が表示されることを試してください
    1. ログインに失敗すると、ログインに失敗した理由がフラッシュメッセージで表示される
        - **Danger(薄い赤背景)**のフラッシュメッセージ 
        - 表示内容はDeviceデフォルトのメッセージ
    1. ログインに成功すると、「ログインしました」のフラッシュメッセージが表示される
        - **Success(薄い緑背景)**のフラッシュメッセージ 
        - 表示内容はDeviceデフォルトのメッセージ
  
1. ワード詳細画面にアクセスし、以下が表示されることを試してください
    1. [エピソードを追加]のテキストエリアを空欄のまま[追加]ボタンを押下
        - **Danger(薄い赤背景)**のフラッシュメッセージ 
        - 「エピソードを投稿できませんでした」が表示される
    1. [エピソードを追加]のテキストエリアを入力し[追加]ボタンを押下
        - **Success(薄い緑背景)**のフラッシュメッセージ 
        - 「エピソードを投稿しました」が表示される
1. [# 4-4-2. 共通機能：フラッシュメッセージパーシャル](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/27)の実装概要が全てクリアしていることをご確認ください。

## その他
1. 今後フラッシュメッセージを実装する際には以下のどちらかのflash_typeを選んでください
    - 成功・通知系…success
    - 失敗・警告系…danger
3. **【優先度低】**Deviceの通知について
    DeviseのFlashメッセージは、デフォルトでflash_type `notice` `alert` を使用しています。
    DeviseのFlashメッセージも、`success` `dabger`を使用できるように修正可能でしたら、修正いただけると幸いです。
    修正いただけた場合、以下の余分なカスタムCSSを削除するようにいたします。
      - `alert-notice`
      - `alert-alert`
    なお、MVPリリース段階では、機能的に問題ないため対応いただかなくてもOKです！