### PR TITLE
04-01_01_ワード投稿・編集機能/未ログインユーザーのアクセス制限の実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,7 @@
 
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
+  # before_action :authenticate_user!
   add_flash_types :success, :danger
   # def current_or_guest_user
   #   current_user || gest_user = User.find(0) || User.create!(id: 0, name: "Gest", email: "gest@test.com", password: "gestuser")

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,7 +2,7 @@
 
 class ApplicationController < ActionController::Base
   before_action :configure_permitted_parameters, if: :devise_controller?
-  # before_action :authenticate_user!
+  before_action :authenticate_user!
   add_flash_types :success, :danger
   # def current_or_guest_user
   #   current_user || gest_user = User.find(0) || User.create!(id: 0, name: "Gest", email: "gest@test.com", password: "gestuser")

--- a/app/controllers/episodes_controller.rb
+++ b/app/controllers/episodes_controller.rb
@@ -1,5 +1,5 @@
 class EpisodesController < ApplicationController
-  # skip_before_action :authenticate_user!, only: %i[create]
+  skip_before_action :authenticate_user!, only: %i[create]
 
   def create
     @episode = current_or_guest_user.episodes.build(episode_params)

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -30,6 +30,12 @@ class PostsController < ApplicationController
 
   def update
     @post = current_user.posts.find(params[:id])
+    if @post.update(post_params)
+      redirect_to post_path(@post), success: "ワードを更新しました"
+    else
+      flash.now[:danger] = "ワードを更新できませんでした"
+      render :edit, status: :unprocessable_entity
+    end
   end
 
   private

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -9,7 +9,13 @@ class PostsController < ApplicationController
   end
 
   def create
-    @post = Post.new
+    @post = current_user.posts.build(post_params)
+    if @post.save
+      redirect_to post_path(@post), success: "ワードを投稿しました"
+    else
+      flash.now[:danger] = "ワードを投稿できませんでした"
+      render :new, status: :unprocessable_entity
+    end
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,6 +1,15 @@
 class PostsController < ApplicationController
+  # skip_before_action :authenticate_user!, only: %i[index show]
   def index
     @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
+  end
+
+  def new
+    @post = Post.new
+  end
+
+  def create
+    @post = Post.new
   end
 
   def show

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -11,9 +11,9 @@ class PostsController < ApplicationController
   def create
     @post = current_user.posts.build(post_params)
     if @post.save
-      redirect_to post_path(@post), success: "ワードを投稿しました"
+      redirect_to post_path(@post), success: t('defaults.flash_message.posted', item: Post.model_name.human)
     else
-      flash.now[:danger] = "ワードを投稿できませんでした"
+      flash.now[:danger] = t('defaults.flash_message.not_posted', item: Post.model_name.human)
       render :new, status: :unprocessable_entity
     end
   end
@@ -31,9 +31,9 @@ class PostsController < ApplicationController
   def update
     @post = current_user.posts.find(params[:id])
     if @post.update(post_params)
-      redirect_to post_path(@post), success: "ワードを更新しました"
+      redirect_to post_path(@post), success: t('defaults.flash_message.updated', item: Post.model_name.human)
     else
-      flash.now[:danger] = "ワードを更新できませんでした"
+      flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
       render :edit, status: :unprocessable_entity
     end
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -1,5 +1,5 @@
 class PostsController < ApplicationController
-  # skip_before_action :authenticate_user!, only: %i[index show]
+  skip_before_action :authenticate_user!, only: %i[index show]
   def index
     @posts = Post.includes(:user).order(created_at: :desc).page(params[:page])
   end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -24,6 +24,14 @@ class PostsController < ApplicationController
     @episodes = @post.episodes.includes(:user).order(created_at: :desc)
   end
 
+  def edit
+    @post = current_user.posts.find(params[:id])
+  end
+
+  def update
+    @post = current_user.posts.find(params[:id])
+  end
+
   private
 
   def post_params

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -8,5 +8,5 @@
     <%= f.label :body, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_area :body, class: "form-control w-full p-2 border border-gray-300 rounded mb-3", rows: "5", placeholder: "ワードの説明"%>
   </div>
-  <%= f.submit "登録", class: "w-200 mb-6 bg-orange-400 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
+  <%= f.submit nil, class: "w-200 mb-6 bg-orange-400 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
 <% end %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,11 +1,11 @@
 <%= form_with model: post do |f| %>
   <% # render 'shared/error_messages', object: f.object %>
   <div class="mb-3">
-    <%= f.label :title, "ワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :title, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_field :title, class: "form-control w-full p-2 border border-gray-300 rounded mb-3", placeholder: "思い出のワード" %>
   </div>
   <div class="mb-3">
-    <%= f.label :body, "意味", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.label :body, class: "block text-sm font-medium text-gray-700 mb-1" %>
     <%= f.text_area :body, class: "form-control w-full p-2 border border-gray-300 rounded mb-3", rows: "5", placeholder: "ワードの説明"%>
   </div>
   <%= f.submit "登録", class: "w-200 mb-6 bg-orange-400 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -1,0 +1,12 @@
+<%= form_with model: post do |f| %>
+  <% # render 'shared/error_messages', object: f.object %>
+  <div class="mb-3">
+    <%= f.label :title, "ワード", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_field :title, class: "form-control w-full p-2 border border-gray-300 rounded mb-3", placeholder: "思い出のワード" %>
+  </div>
+  <div class="mb-3">
+    <%= f.label :body, "意味", class: "block text-sm font-medium text-gray-700 mb-1" %>
+    <%= f.text_area :body, class: "form-control w-full p-2 border border-gray-300 rounded mb-3", rows: "5", placeholder: "ワードの説明"%>
+  </div>
+  <%= f.submit "登録", class: "w-200 mb-6 bg-orange-400 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
+<% end %>

--- a/app/views/posts/edit.html.erb
+++ b/app/views/posts/edit.html.erb
@@ -1,0 +1,8 @@
+<div class="container mx-auto pt-5">
+  <div class="mb-3">
+    <div class="lg:w-2/3 lg:mx-auto">
+      <h1 class="text-2xl font-bold mb-6"><%= "ワードを編集" %></h1>
+      <%= render 'form', post: @post %>
+    </div>
+  </div>
+</div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -1,0 +1,8 @@
+<div class="container mx-auto pt-5">
+  <div class="mb-3">
+    <div class="lg:w-2/3 lg:mx-auto">
+      <h1 class="text-2xl font-bold mb-6"><%= "ワードを登録" %></h1>
+      <%= render 'form', post: @post %>
+    </div>
+  </div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,7 +6,7 @@
     <% end %>
       <ul class="flex">
         <li class="text-base mr-12">
-          <%= link_to "ワードを登録", '#' %>
+          <%= link_to "ワードを登録", new_post_path %>
         </li>
         <li class="text-base mr-12">
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -6,3 +6,10 @@ ja:
         title: "ログイン"
     failure:
       invalid: "無効なメールアドレスまたはパスワードです。"
+  activerecord:
+    models:
+      post: ワード
+  attributes:
+    post:
+      title: ワード
+      body: 意味

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,7 +9,7 @@ ja:
   activerecord:
     models:
       post: ワード
-  attributes:
-    post:
-      title: ワード
-      body: 意味
+    attributes:
+      post:
+        title: ワード
+        body: 意味

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -1,0 +1,19 @@
+ja:
+  helpers:
+    submit:
+      create: 登録
+      submit: 保存
+  defaults:
+    flash_message:
+      created: "%{item}を作成しました"
+      not_created: "%{item}を作成出来ませんでした"
+      updated: "%{item}を更新しました"
+      not_updated: "%{item}を更新出来ませんでした"
+      require_login: ログインしてください
+  posts:
+    new:
+      title: ワード作成
+    edit:
+      title: ワード編集
+    show:
+      title: ワード詳細

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -3,6 +3,7 @@ ja:
     submit:
       create: 登録
       submit: 保存
+      update: 更新
   defaults:
     flash_message:
       created: "%{item}を作成しました"

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -8,6 +8,8 @@ ja:
     flash_message:
       created: "%{item}を作成しました"
       not_created: "%{item}を作成出来ませんでした"
+      posted: "%{item}を投稿しました"
+      not_posted: "%{item}を投稿出来ませんでした"
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       require_login: ログインしてください

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root 'posts#index'
-  resources :posts, only: %i[new create show] do
+  resources :posts, only: %i[new create show edit update] do
     resources :episodes, only: %i[create edit destroy], shallow: true
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root 'posts#index'
-  resources :posts, only: %i[show] do
+  resources :posts, only: %i[new create show] do
     resources :episodes, only: %i[create edit destroy], shallow: true
   end
 end


### PR DESCRIPTION
close #17,#18
#41

## 概要
- ワード投稿機能の実装
- ワード編集機能の実装
- 未ログインユーザーのアクセス制限の実装

## チケットへのリンク
- [# 4-1. ワード登録画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/17)
- [# 4-2. ワード編集画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/18)
- [10-01_未ログインユーザーのアクセス制限](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/41)

## やったこと
### [# 4-1. ワード登録画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/17)
- ワード投稿機能の実装
	- ルーティング設定
	- アクションの作成
		- post#new
		- post#create
	- ビューの作成
		- app/views/posts/new.html.erb
		- app/views/posts/_form.html.erb
- i18n対応
- ヘッダーからの導線の確保

### [# 4-2. ワード編集画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/18)
- ワード編集機能の実装
	- ルーティング設定
	- アクションの作成
		- post#edit
		- post#update
	- ビューの作成
		- app/views/posts/edit.html.erb

### [10-01_未ログインユーザーのアクセス制限](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/41)
- application_controller.rbで`before_action :authenticate_user!`を記載
- `skip_before_action :authenticate_user!, only: %i[○○]`で未ログインにアクセス許可
	- post_controller
		- index
		- show
	- episode_controller
	  - create

## やらないこと
### [# 4-1. ワード登録画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/17)
- フォーム入力時エラー情報表示…[# 4-4-1. 共通機能：フォーム入力時エラー情報パーシャル](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/26)で作成後、実装予定
### [# 4-2. ワード編集画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/18)
- フォーム入力時エラー情報表示…[# 4-4-1. 共通機能：フォーム入力時エラー情報パーシャル](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/26)で作成後、実装予定
### [10-01_未ログインユーザーのアクセス制限](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/41)
- 未実装機能のアクセス制限・許可
	- ワード削除
	- タグ関連

## できるようになること(ユーザ目線)
- ワードの投稿
- ワードの編集

## できなくなること(ユーザ目線)
特になし

## 影響範囲
- アプリケーション全体で、未ログインユーザーのアクセス制限を実施

## 動作確認とその方法
### [# 4-1. ワード登録画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/17)
- ワードが投稿機能の確認
  - ヘッダーの「ワードを登録」からワード登録画面に遷移
  - ワードが投稿できることを確認
	  - ワード詳細画面に遷移し、フラッシュメッセージ「ワードを投稿しました」が表示されること
	  - ※ローカルだと[意味]を上限文字数(65,535文字)付近で投稿するとMySQL側でエラーが発生してしまいます。(Rails基礎も同様。なお、[Rails基礎のサンプル](https://runteq-normal-curriculum.herokuapp.com/boards/1828)は、65,535文字も投稿できる)[意味]は、1,000字以内程度で投稿できることをお試しください。
- ワード投稿のバリデーションの確認
	- ヘッダーの「ワードを登録」からワード登録画面に遷移
	- ワード・意味どちらかが空欄の場合、ワード投稿に失敗すること
	- 文字数オーバーでワード投稿が失敗すること
		‐ ワード：255文字より多い文字
		- 意味：65,535文字より多い文字
	- フラッシュメッセージ「ワードを投稿できませんでした」が表示されること

### [# 4-2. ワード編集画面](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/18)
- ワード編集機能の確認
  - ログイン中のユーザーが投稿したワードの詳細画面に遷移
  - URLの末尾に`/edit`を付けて、ワード編集画面に遷移
  - ワードを編集できることを確認
	  - ワード詳細画面に遷移し、フラッシュメッセージ「ワードを更新しました」が表示されること
	  - ※ローカルだと[意味]を上限文字数(65,535文字)付近で投稿するとMySQL側でエラーが発生してしまいます。(Rails基礎も同様。なお、[Rails基礎のサンプル](https://runteq-normal-curriculum.herokuapp.com/boards/1828)は、65,535文字も投稿できる)[意味]は、1,000字以内程度で更新できることをお試しください。
- ワード更新のバリデーションの確認
  - ログイン中のユーザーが投稿したワードの詳細画面に遷移
  - URLの末尾に`/edit`を付けて、ワード編集画面に遷移
	- ワード・意味どちらかが空欄の場合、ワード更新に失敗すること
	- 文字数オーバーでワード更新が失敗すること
		‐ ワード：255文字より多い文字
		- 意味：65,535文字より多い文字
	- フラッシュメッセージ「ワードを更新できませんでした」が表示されること
- 別のユーザーの投稿編集不可の確認
	- 別のユーザーが投稿したワード詳細画面に遷移
	- URLの末尾に`/edit`を付けて、ワード編集画面に遷移
	- エラー画面が表示されること
	
### [10-01_未ログインユーザーのアクセス制限](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/41)
- 未ログインユーザーのアクセス制限の確認
	- 未ログインユーザーのアクセスが[権限別機能一覧表](https://www.notion.so/62-Group1-Notion-17ab3cd2cca980a5bd6ad608bee787de?pvs=4#5cf2d8bf45a84350a5218f09070d45e3)の通りになっているかご確認ください。
	- ※ワード投稿・編集へのアクセスは、URLを直接叩いてご確認ください。
	- ※未実装機能(ワード削除・タグ関連)以外をご確認ください。

## その他
タグ関連、ワード削除関連の機能実装の際には、[10-01_未ログインユーザーのアクセス制限](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/41)も併せてご確認ください。
タグ関連実装時、[10-01_未ログインユーザーのアクセス制限](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/41)のチェック項目が全てチェック付いたら、本issueのクローズもお願いします。
