### PR TITLE
01_01_headerのicon設定

### DIFF
--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -6,13 +6,13 @@
     <% end %>
       <ul class="flex">
         <li class="text-base mr-12">
-          <%= link_to "ワードを登録", '#' %>
+          <i class="fa-regular fa-square-plus pr-1"></i><%= link_to "ワードを登録", '#' %>
         </li>
         <li class="text-base mr-12">
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>
         </li>
         <li class="text-base mr-5">
-          <div><%= current_user.name %></div>
+          <div><i class="fa-regular fa-user pr-1"></i><%= current_user.name %></div>
         </li>
       </ul>
     </div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -5,8 +5,10 @@
       <%= image_tag 'logo.png', size: "195x23" %>
     <% end %>
       <ul class="flex">
-        <li class="text-base mr-12">
-          <i class="fa-regular fa-square-plus pr-1"></i><%= link_to "ワードを登録", '#' %>
+        <li class="text-base mr-12 flex"">
+          <%= link_to '#'  do %>
+            <i class="fa-regular fa-square-plus pr-1"></i><span>ワードを登録</span>
+          <% end %>
         </li>
         <li class="text-base mr-12">
           <%= link_to "ログアウト", destroy_user_session_path, method: :delete %>


### PR DESCRIPTION
close #5
## 概要
ログイン後のヘッダーに以下のiconを設定
- ワード登録icon
- ユーザーicon
[![Image from Gyazo](https://i.gyazo.com/cbb78890cfab102c036aebc9b12ed89e.jpg)](https://gyazo.com/cbb78890cfab102c036aebc9b12ed89e)

## チケットへのリンク
[# 01_ヘッダーの作成](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/5)
## やったこと
- app/views/shared/_header.html.erbにてiconの設定

## やらないこと
- 「ワードを登録」リンク設定…プルリク[04-01_01_ワード投稿・編集機能/未ログインユーザーのアクセス制限の実装](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/pull/42)で実装済み

## できるようになること(ユーザ目線)
- ログイン後のヘッダーにiconが表示される

## できなくなること(ユーザ目線)
特になし

## 影響範囲
特になし

## 動作確認とその方法
ログイン後、ヘッダーに以下のiconが表示されることを確認ください
- ワードを登録の左隣にプラスのicon
- ユーザー名の左隣に人のicon

## その他
ユーザーのiconについて、[# 01_ヘッダーの作成](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/5)の画面モックでは、font awesomeの「circle-plus」がイメージが近いですが、「circle-plus」は有料版のみ使用可能となります。
今回は、無料で使用可能な「square-plus」で代替しました。
[font awesome plusアイコン](https://fontawesome.com/search?q=plus&ip=classic&s=regular&o=r)
[![Image from Gyazo](https://i.gyazo.com/5f3f9fb89d38e404b4652a606e3140b4.png)](https://gyazo.com/5f3f9fb89d38e404b4652a606e3140b4)