### PR TITLE
04-03-01-01_ワード詳細画面の見た目の調整

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -38,6 +38,12 @@ class PostsController < ApplicationController
     end
   end
 
+  def destroy
+    post = current_user.posts.find(params[:id])
+    post.destroy!
+    redirect_to root_path, success: t('defaults.flash_message.deleted', item: Post.model_name.human)
+  end
+
   private
 
   def post_params

--- a/app/views/episodes/_episode.html.erb
+++ b/app/views/episodes/_episode.html.erb
@@ -1,20 +1,22 @@
 <tr id="episode-<%= episode.id %>">
-  <td class="w-16">
-    <% # image_tag "sample", width: "50", height: "50", class: "rounded-full" %>
+  <td class="w-1">
   </td>
   <td>
-    <h3 class="text-sm font-semibold"><i class="fa-regular fa-user"></i><%= episode.user.name %></h3>
+    <div class="flex justify-between">
+      <h3 class="text-sm font-semibold"><i class="fa-regular fa-user"></i><%= episode.user.name %></h3>
+      <% if current_user&.own?(episode) %><!--- 自分の投稿なら削除ボタン表示(未ログインだとcurrent_userがnill⇒ぼっち演算子でnilを返し、if文がfalse扱い) --->
+        <div class="action">
+          <ul class="flex justify-end space-x-2">
+            <li>
+              <%= link_to episode_path(episode), class: "delete-episode-link", data: { turbo_method: :delete, turbo_confirm: "削除しますか?" } do %>
+                <i class="fa-solid fa-trash" style="color: #F49849;"></i>
+              <% end %>
+            </li>
+          </ul>
+        </div>
+      <% end %>
+    </div>
     <p class="text-gray-700"><%= simple_format(episode.body) %></p>
+    <div class="border-dotted border-b border-gray-200 mb-3"></div>
   </td>
-  <% if current_user&.own?(episode) %><!--- 自分の投稿なら削除ボタン表示(未ログインだとcurrent_userがnill⇒ぼっち演算子でnilを返し、if文がfalse扱い) --->
-    <td class="action">
-      <ul class="flex justify-end space-x-2">
-        <li>
-          <%= link_to episode_path(episode), class: "delete-episode-link", data: { turbo_method: :delete, turbo_confirm: "削除しますか?" } do %>
-            <i class="fa-solid fa-trash" style="color: #FFD43B;"></i>
-          <% end %>
-        </li>
-      </ul>
-    </td>
-  <% end %>
 </tr>

--- a/app/views/episodes/_form.html.erb
+++ b/app/views/episodes/_form.html.erb
@@ -4,13 +4,13 @@
       <% # render 'shared/error_messages', object: f.object %>
 
       <!-- ラベル -->
-      <%= f.label :body, "エピソードを追加", class: "block text-sm font-medium text-gray-700 mb-1" %>
+      <%= f.label :body, "エピソードを追加", class: "block text-lg font-medium text-gray-700 mb-1" %>
 
       <!-- テキストエリア -->
       <%= f.text_area :body, class: "form-control w-full p-2 border border-gray-300 rounded mb-3", rows: "4", placeholder: "この思い出にまつわるエピソードを教えてください！" %>
 
       <!-- 送信ボタン -->
-      <%= f.submit "追加", class: "bg-blue-500 text-white font-semibold px-4 py-2 rounded hover:bg-blue-600" %>
+      <%= f.submit "追加", class: "w-200 mb-6 bg-orange-400 hover:bg-orange-600 text-white font-bold py-2 px-4 rounded-md shadow-md transition" %>
     <% end %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,35 +1,39 @@
 <div class="container mx-auto pt-5">
   <div class="mb-3">
     <div class="lg:w-2/3 lg:mx-auto">
-      <h1 class="text-3xl font-bold"><%= "ワード詳細" %></h1>
-      <article class="bg-white shadow rounded-lg overflow-hidden">
-        <div class="p-6">
-          <div class="flex flex-col md:flex-row gap-4">
-            <div class="md:w-3/4">
-              <h3 class="text-xl font-semibold inline"><%= @post.title %></h3>
-              <ul class="flex gap-2 text-gray-500 text-sm">
-                <li><%= "by #{@post.user.name}" %></li>
-              </ul>
-            </div>
-          </div>
-          <p class="mt-4 text-gray-800"><%= simple_format(@post.body) %></p>
-        </div>
+      <article class="bg-white">
+        <h1 class="text-3xl font-bold"><%= @post.title %></h1>
+        <ul class="flex justify-end space-x-2">
+          <li class="flex gap-2 text-gray-500 text-sm"><%= "by #{@post.user.name}" %></li>
+          <li>
+            <%= link_to edit_post_path(@post), id: "button-edit-#{@post.id}" do %>
+              <i class="fa-solid fa-pencil" style="color: #F49849;"></i>
+            <% end %>
+          </li>
+          <li>
+            <%= link_to post_path(@post), id: "button-delete-#{@post.id}", data: { turbo_method: :delete, turbo_confirm: "削除しますか?" } do %>
+              <i class="fa-solid fa-trash" style="color: #F49849;"></i>
+            <% end %>
+          </li>
+        </ul>
+        <h2 class="text-2xl font-semibold inline"><%= "意味" %></h2>
+        <div class="border-b border-gray-200 mb-1"></div>
+        <p class="mt-2 text-gray-800"><%= simple_format(@post.body) %></p>
       </article>
     </div>
   </div>
-  <div class="flex justify-center">
-    <div class="w-full lg:w-8/12">
-      <table class="w-full border-collapse border border-gray-200">
-        <h1 class="text-3xl font-bold"><%= "エピソード" %></h1>
-        <tbody id="table-episode">
-            <% if @post.episodes.empty? %>
-              <p>エピソードはまだありません</p>
-            <% else %>
-              <%= render @episodes %>
-            <% end %>
-        </tbody>
-      </table>
-      <%= render 'episodes/form', episode: @episode, post: @post %>
-    </div>
+  <div class="w-full lg:w-2/3">
+    <table class="w-full border-gray-200 mb-3">
+      <h2 class="text-2xl mt-5 font-semibold"><%= "エピソード" %></h2>
+      <div class="border-b border-gray-200 mb-1"></div>
+      <tbody id="table-episode">
+          <% if @post.episodes.empty? %>
+            <p>エピソードはまだありません</p>
+          <% else %>
+            <%= render @episodes %>
+          <% end %>
+      </tbody>
+    </table>
+    <%= render 'episodes/form', episode: @episode, post: @post %>
   </div>
 </div>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -22,18 +22,20 @@
       </article>
     </div>
   </div>
-  <div class="w-full lg:w-2/3">
-    <table class="w-full border-gray-200 mb-3">
-      <h2 class="text-2xl mt-5 font-semibold"><%= "エピソード" %></h2>
-      <div class="border-b border-gray-200 mb-1"></div>
-      <tbody id="table-episode">
-          <% if @post.episodes.empty? %>
-            <p>エピソードはまだありません</p>
-          <% else %>
-            <%= render @episodes %>
-          <% end %>
-      </tbody>
-    </table>
-    <%= render 'episodes/form', episode: @episode, post: @post %>
+  <div class="flex justify-center">
+    <div class="w-full lg:w-2/3">
+      <table class="w-full border-gray-200 mb-3">
+        <h2 class="text-2xl mt-5 font-semibold"><%= "エピソード" %></h2>
+        <div class="border-b border-gray-200 mb-1"></div>
+        <tbody id="table-episode">
+            <% if @post.episodes.empty? %>
+              <p>エピソードはまだありません</p>
+            <% else %>
+              <%= render @episodes %>
+            <% end %>
+        </tbody>
+      </table>
+    </div>
   </div>
+  <%= render 'episodes/form', episode: @episode, post: @post %>
 </div>

--- a/config/locales/views/ja.yml
+++ b/config/locales/views/ja.yml
@@ -13,6 +13,7 @@ ja:
       updated: "%{item}を更新しました"
       not_updated: "%{item}を更新出来ませんでした"
       require_login: ログインしてください
+      deleted: "%{item}を削除しました"
   posts:
     new:
       title: ワード作成

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,7 +12,7 @@ Rails.application.routes.draw do
   # Defines the root path route ("/")
   # root "articles#index"
   root 'posts#index'
-  resources :posts, only: %i[new create show edit update] do
+  resources :posts, only: %i[new create show edit update destroy] do
     resources :episodes, only: %i[create edit destroy], shallow: true
   end
 end


### PR DESCRIPTION
#21, #22
close, #23 
close, #24

## 概要
- ワード詳細ページの見た目の調整
- ワード編集・削除ボタン配置
[![Image from Gyazo](https://i.gyazo.com/d1bdb08db4a39e513468cbb27f2346fa.png)](https://gyazo.com/d1bdb08db4a39e513468cbb27f2346fa)

## チケットへのリンク
[# 4-3-1-1. ワード詳細画面：ワード詳細表示](https://github.com/RUNTEQ-62-GROUP-DEVELOPMENT/Group1/issues/21)

## やったこと
- ワード詳細ページの見た目の調整
  - ワードの表示調整
  - 意味欄の調整
  - エピソード欄の調整
- ワード編集ボタンの実装
- ワード削除ボタンの実装
- ワード削除機能の実装

## やらないこと
- ワード編集・削除ボタンを投稿者のワード詳細画面にのみ表示(後日実装)

## できるようになること(ユーザ目線)
- ワードの編集・削除

## できなくなること(ユーザ目線)
特になし

## 影響範囲
i18n対応として、config/locales/views/ja.ymlにdefaults/flash_messageの日本語訳を追加しました。

## 動作確認とその方法
- ワード詳細画面にアクセスし、見た目を確認してください
  - ワード欄
    - ワードの表示位置
    - 投稿アカウント名・編集・削除ボタンの表示位置
  - 意味欄
  - エピソード欄
  - エピソード投稿欄
- ワード編集ボタンの確認
  - ログインユーザーが投稿したワードのワード編集ボタンを押下し、ワードの編集が行えることを確認ください
- ワード削除ボタンの確認
  - ログインユーザーが投稿したワードのワード削除ボタンを押下し、ワードの削除が行えることを確認ください
  - 「削除しますか？」のポップアップが出ること
  - 削除後に「ワードを削除しました」というフラッシュメッセージが表示されること

## その他
特になし